### PR TITLE
ceres-solver 2.2.0: add CUDA 12.9/13.0 variants (linux + win-64)

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -2,7 +2,7 @@
 echo "Building %PKG_NAME%."
 
 set "CUDA_CMAKE_ARGS=-DUSE_CUDA=OFF"
-if defined cuda_compiler_version if not "%cuda_compiler_version%"=="None" (
+if "%gpu_variant%"=="cuda" (
     rem CMAKE_CUDA_STANDARD=17 is required for CUDA 13's Thrust/CCCL on MSVC;
     rem nvcc otherwise inherits MSVC's older default and Thrust refuses to compile
     rem (fatal error C1189: "Thrust requires at least C++17").

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -3,7 +3,10 @@ echo "Building %PKG_NAME%."
 
 set "CUDA_CMAKE_ARGS=-DUSE_CUDA=OFF"
 if defined cuda_compiler_version if not "%cuda_compiler_version%"=="None" (
-    set "CUDA_CMAKE_ARGS=-DUSE_CUDA=ON"
+    rem CMAKE_CUDA_STANDARD=17 is required for CUDA 13's Thrust/CCCL on MSVC;
+    rem nvcc otherwise inherits MSVC's older default and Thrust refuses to compile
+    rem (fatal error C1189: "Thrust requires at least C++17").
+    set "CUDA_CMAKE_ARGS=-DUSE_CUDA=ON -DCMAKE_CUDA_STANDARD=17"
     rem nvcc 13.x dropped Maxwell/Pascal/Volta. Rewrite Ceres 2.2.0's
     rem hardcoded "50;60;70;80" arch list for cuda 13.* only (mirrors build.sh).
     echo %cuda_compiler_version% | findstr /b "13." >nul && powershell -NoProfile -Command "(Get-Content -Raw CMakeLists.txt) -replace '\"50;60;70;80\"', '\"75;80;86;90\"' | Set-Content -NoNewline CMakeLists.txt"

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,6 +1,14 @@
 :: cmd
 echo "Building %PKG_NAME%."
 
+set "CUDA_CMAKE_ARGS=-DUSE_CUDA=OFF"
+if defined cuda_compiler_version if not "%cuda_compiler_version%"=="None" (
+    set "CUDA_CMAKE_ARGS=-DUSE_CUDA=ON"
+    rem nvcc 13.x dropped Maxwell/Pascal/Volta. Rewrite Ceres 2.2.0's
+    rem hardcoded "50;60;70;80" arch list for cuda 13.* only (mirrors build.sh).
+    echo %cuda_compiler_version% | findstr /b "13." >nul && powershell -NoProfile -Command "(Get-Content CMakeLists.txt) -replace '\"50;60;70;80\"', '\"75;80;86;90\"' | Set-Content -NoNewline CMakeLists.txt"
+)
+
 mkdir build_ && cd build_
 if errorlevel 1 exit /b 1
 
@@ -14,6 +22,7 @@ cmake .. %CMAKE_ARGS% ^
     -DBUILD_SHARED_LIBS=ON ^
     -DBUILD_EXAMPLES=OFF ^
     -DBUILD_TESTING=OFF ^
+    %CUDA_CMAKE_ARGS% ^
     ..
 if errorlevel 1 exit /b 1
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -6,7 +6,7 @@ if defined cuda_compiler_version if not "%cuda_compiler_version%"=="None" (
     set "CUDA_CMAKE_ARGS=-DUSE_CUDA=ON"
     rem nvcc 13.x dropped Maxwell/Pascal/Volta. Rewrite Ceres 2.2.0's
     rem hardcoded "50;60;70;80" arch list for cuda 13.* only (mirrors build.sh).
-    echo %cuda_compiler_version% | findstr /b "13." >nul && powershell -NoProfile -Command "(Get-Content CMakeLists.txt) -replace '\"50;60;70;80\"', '\"75;80;86;90\"' | Set-Content -NoNewline CMakeLists.txt"
+    echo %cuda_compiler_version% | findstr /b "13." >nul && powershell -NoProfile -Command "(Get-Content -Raw CMakeLists.txt) -replace '\"50;60;70;80\"', '\"75;80;86;90\"' | Set-Content -NoNewline CMakeLists.txt"
 )
 
 mkdir build_ && cd build_

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,13 @@
 #!/bin/sh
+set -ex
 
 mkdir build_ && cd build_
+
+if [ -n "${cuda_compiler_version}" ] && [ "${cuda_compiler_version}" != "None" ]; then
+  CUDA_CMAKE_ARGS="-DUSE_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=all"
+else
+  CUDA_CMAKE_ARGS="-DUSE_CUDA=OFF"
+fi
 
 cmake ${CMAKE_ARGS} \
   -DCMAKE_PREFIX_PATH=${PREFIX} \
@@ -10,5 +17,6 @@ cmake ${CMAKE_ARGS} \
   -DBUILD_EXAMPLES=OFF \
   -DBUILD_TESTING=OFF \
   -DLIB_SUFFIX="" \
+  ${CUDA_CMAKE_ARGS} \
   ..
 make install -j${CPU_COUNT}

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,13 +1,22 @@
 #!/bin/sh
 set -ex
 
-mkdir build_ && cd build_
-
 if [ -n "${cuda_compiler_version}" ] && [ "${cuda_compiler_version}" != "None" ]; then
-  CUDA_CMAKE_ARGS="-DUSE_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=all"
+  CUDA_CMAKE_ARGS="-DUSE_CUDA=ON"
+  case "${cuda_compiler_version}" in
+    13.*)
+      # Ceres 2.2.0 CMakeLists hardcodes "50;60;70;80" (unguarded set()), which
+      # nvcc 13.x rejects — Maxwell/Pascal/Volta were dropped. Rewrite in place
+      # to Turing+Ampere+Hopper. (-DCMAKE_CUDA_ARCHITECTURES is silently
+      # overridden by Ceres' unconditional set(), so we patch the source.)
+      sed -i 's/"50;60;70;80"/"75;80;86;90"/' CMakeLists.txt
+      ;;
+  esac
 else
   CUDA_CMAKE_ARGS="-DUSE_CUDA=OFF"
 fi
+
+mkdir build_ && cd build_
 
 cmake ${CMAKE_ARGS} \
   -DCMAKE_PREFIX_PATH=${PREFIX} \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -ex
 
-if [ -n "${cuda_compiler_version}" ] && [ "${cuda_compiler_version}" != "None" ]; then
+if [ "${gpu_variant}" = "cuda" ]; then
   CUDA_CMAKE_ARGS="-DUSE_CUDA=ON"
   case "${cuda_compiler_version}" in
     13.*)

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -6,8 +6,10 @@ mkl:
 cuda_compiler:
   - cuda-nvcc
 
-# Build a CPU variant on every platform, plus CUDA 12.9 / 13.0 on Linux only.
+# Build a CPU variant on every platform, plus CUDA 12.9 / 13.0 on linux and
+# win-64. (Matches the aggregate CBC's `[linux or (win and x86_64)]` selector
+# for CUDA; aggregate has no None entry so we add it for the CPU matrix slot.)
 cuda_compiler_version:
   - None
-  - 12.9       # [linux]
-  - 13.0       # [linux]
+  - 12.9       # [linux or (win and x86_64)]
+  - 13.0       # [linux or (win and x86_64)]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,13 @@
 mkl:
   - 2025
+
+# Keep cuda_compiler in the local CBC even when the aggregate sets it,
+# otherwise {{ compiler('cuda') }} fails to resolve for CPU-only matrix entries.
+cuda_compiler:
+  - cuda-nvcc
+
+# Build a CPU variant on every platform, plus CUDA 12.9 / 13.0 on Linux only.
+cuda_compiler_version:
+  - None
+  - 12.9       # [linux]
+  - 13.0       # [linux]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,15 +1,26 @@
 mkl:
   - 2025
 
-# Keep cuda_compiler in the local CBC even when the aggregate sets it,
-# otherwise {{ compiler('cuda') }} fails to resolve for CPU-only matrix entries.
-cuda_compiler:
-  - cuda-nvcc
+# Keep cuda_compiler in the local CBC even when the aggregate sets it —
+# without it {{ compiler('cuda') }} fails to resolve at metadata-eval time.
+cuda_compiler:                          # [linux or (win and x86_64)]
+  - cuda-nvcc                           # [linux or (win and x86_64)]
 
-# Build a CPU variant on every platform, plus CUDA 12.9 / 13.0 on linux and
-# win-64. (Matches the aggregate CBC's `[linux or (win and x86_64)]` selector
-# for CUDA; aggregate has no None entry so we add it for the CPU matrix slot.)
-cuda_compiler_version:
-  - None
-  - 12.9       # [linux or (win and x86_64)]
-  - 13.0       # [linux or (win and x86_64)]
+# gpu_variant is the structural CPU/GPU selector per AnacondaRecipes
+# convention (arrow-cpp, lightgbm, pytorch/torchvision, llama.cpp, catboost
+# all use this). zip_keys couples it with cuda_compiler_version so the
+# (variant, version) pair stays aligned across the matrix expansion.
+gpu_variant:
+  - none
+  - cuda                                # [linux or (win and x86_64)]
+  - cuda                                # [linux or (win and x86_64)]
+
+cuda_compiler_version:                  # [linux or (win and x86_64)]
+  - none                                # [linux or (win and x86_64)]
+  - 12.9                                # [linux or (win and x86_64)]
+  - 13.0                                # [linux or (win and x86_64)]
+
+zip_keys:                               # [linux or (win and x86_64)]
+  -                                     # [linux or (win and x86_64)]
+    - gpu_variant                       # [linux or (win and x86_64)]
+    - cuda_compiler_version             # [linux or (win and x86_64)]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,10 @@
 {% set name = "ceres-solver" %}
 {% set version = "2.2.0" %}
+{% set processor = "cpu" if (cuda_compiler_version or "None") == "None" else "gpu" %}
+
+# Prioritize the GPU build when __cuda is available on the host
+{% set build = 2 %}
+{% set build = build + 100 if processor == "gpu" else build %}
 
 package:
   name: {{ name|lower }}
@@ -10,7 +15,8 @@ source:
   sha256: 48b2302a7986ece172898477c3bcd6deb8fb5cf19b3327bc49969aad4cede82d
 
 build:
-  number: 1
+  number: {{ build }}
+  string: {{ processor }}_h{{ PKG_HASH }}_{{ build }}
   # suitesparse, gflags, glog aren't available on s390x
   skip: true  # [s390x]
   run_exports:
@@ -21,6 +27,7 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - {{ compiler('cuda') }}          # [cuda_compiler_version != "None"]
     - cmake
     - make   # [not win]
     - ninja  # [win]
@@ -39,6 +46,12 @@ requirements:
     - suitesparse 7.8.3
     - tbb 2022.*
     - eigen 3.3.7
+    # CUDA linear-algebra libraries (sparse Schur / dense solvers on GPU)
+    - libcublas-dev                              # [cuda_compiler_version != "None"]
+    - libcusolver-dev                            # [cuda_compiler_version != "None"]
+    - libcusparse-dev                            # [cuda_compiler_version != "None"]
+    - cuda-cudart-dev                            # [cuda_compiler_version != "None"]
+    - cuda-version {{ cuda_compiler_version }}   # [cuda_compiler_version != "None"]
   run:
     # OpenBLAS or MKL
     - mkl {{ mkl }}.*                 # [blas_impl == "mkl"]
@@ -52,6 +65,9 @@ requirements:
     - {{ pin_compatible('suitesparse') }}
     - {{ pin_compatible('tbb') }}
     - eigen >=3.3.7,<3.4.0a0
+    # Require __cuda virtual package so the GPU variant only installs on hosts
+    # with a CUDA-capable driver; the CPU variant is preferred otherwise.
+    - __cuda >={{ cuda_compiler_version }}   # [cuda_compiler_version != "None"]
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,10 +1,11 @@
 {% set name = "ceres-solver" %}
 {% set version = "2.2.0" %}
-{% set processor = "cpu" if (cuda_compiler_version or "None") == "None" else "gpu" %}
+{% set cuda_enabled = (gpu_variant or "none") == "cuda" %}
 
-# Prioritize the GPU build when __cuda is available on the host
+# Build number: bumped from 1 to 2 on this recipe revision; +100 for the
+# GPU variant so the solver prefers it when __cuda is satisfiable.
 {% set build = 2 %}
-{% set build = build + 100 if processor == "gpu" else build %}
+{% set build = build + 100 if cuda_enabled else build %}
 
 package:
   name: {{ name|lower }}
@@ -16,7 +17,8 @@ source:
 
 build:
   number: {{ build }}
-  string: {{ processor }}_h{{ PKG_HASH }}_{{ build }}
+  string: cuda{{ cuda_compiler_version | replace('.', '') }}_h{{ PKG_HASH }}_{{ build }}  # [gpu_variant == "cuda"]
+  string: cpu_h{{ PKG_HASH }}_{{ build }}                                                  # [gpu_variant != "cuda"]
   # suitesparse, gflags, glog aren't available on s390x
   skip: true  # [s390x]
   run_exports:
@@ -27,7 +29,7 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - {{ compiler('cuda') }}          # [cuda_compiler_version != "None"]
+    - {{ compiler('cuda') }}          # [gpu_variant == "cuda"]
     - cmake
     - make   # [not win]
     - ninja  # [win]
@@ -47,11 +49,11 @@ requirements:
     - tbb 2022.*
     - eigen 3.3.7
     # CUDA linear-algebra libraries (sparse Schur / dense solvers on GPU)
-    - libcublas-dev                              # [cuda_compiler_version != "None"]
-    - libcusolver-dev                            # [cuda_compiler_version != "None"]
-    - libcusparse-dev                            # [cuda_compiler_version != "None"]
-    - cuda-cudart-dev                            # [cuda_compiler_version != "None"]
-    - cuda-version {{ cuda_compiler_version }}   # [cuda_compiler_version != "None"]
+    - libcublas-dev                              # [gpu_variant == "cuda"]
+    - libcusolver-dev                            # [gpu_variant == "cuda"]
+    - libcusparse-dev                            # [gpu_variant == "cuda"]
+    - cuda-cudart-dev                            # [gpu_variant == "cuda"]
+    - cuda-version {{ cuda_compiler_version }}   # [gpu_variant == "cuda"]
   run:
     # OpenBLAS or MKL
     - mkl {{ mkl }}.*                 # [blas_impl == "mkl"]
@@ -68,7 +70,7 @@ requirements:
     # __cuda gates the GPU variant to CUDA-capable hosts; the CPU variant
     # (lower build number) installs everywhere else. Version is enforced
     # transitively via cuda-version's run_constrained.
-    - __cuda                                 # [cuda_compiler_version != "None"]
+    - __cuda                                 # [gpu_variant == "cuda"]
 
 test:
   commands:
@@ -80,8 +82,8 @@ test:
     # GPU smoke test: when built with CUDA, libceres must be linked against
     # the CUDA math libs (Linux: verify via ldd) and the cuBLAS runtime must
     # land in the install env (Windows: verify via cublas64*.dll presence).
-    - ldd ${PREFIX}/lib/libceres${SHLIB_EXT} | grep -qE "libcublas|libcusolver|libcusparse"   # [linux and cuda_compiler_version != "None"]
-    - dir /b "%PREFIX%\\Library\\bin\\cublas64*.dll" >nul   # [win and cuda_compiler_version != "None"]
+    - ldd ${PREFIX}/lib/libceres${SHLIB_EXT} | grep -qE "libcublas|libcusolver|libcusparse"   # [linux and gpu_variant == "cuda"]
+    - dir /b "%PREFIX%\\Library\\bin\\cublas64*.dll" >nul   # [win and gpu_variant == "cuda"]
 
 about:
   # HTTPS isn't supported by the ceres-solver.org website

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -77,9 +77,11 @@ test:
     - if not exist %PREFIX%\\Library\\include\\ceres\\ceres.h exit 1  # [win]
     - if not exist %PREFIX%\\Library\\lib\\ceres.lib exit 1  # [win]
     - if not exist %PREFIX%\\Library\\bin\\ceres.dll exit 1  # [win]
-    # GPU smoke test: libceres must be dynamically linked against the CUDA
-    # math libs when built with CUDA — proves USE_CUDA=ON actually took effect.
-    - ldd ${PREFIX}/lib/libceres${SHLIB_EXT} | grep -qE "libcublas|libcusolver|libcusparse"   # [cuda_compiler_version != "None"]
+    # GPU smoke test: when built with CUDA, libceres must be linked against
+    # the CUDA math libs (Linux: verify via ldd) and the cuBLAS runtime must
+    # land in the install env (Windows: verify via cublas64*.dll presence).
+    - ldd ${PREFIX}/lib/libceres${SHLIB_EXT} | grep -qE "libcublas|libcusolver|libcusparse"   # [linux and cuda_compiler_version != "None"]
+    - dir /b "%PREFIX%\\Library\\bin\\cublas64*.dll" >nul   # [win and cuda_compiler_version != "None"]
 
 about:
   # HTTPS isn't supported by the ceres-solver.org website

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -65,9 +65,10 @@ requirements:
     - {{ pin_compatible('suitesparse') }}
     - {{ pin_compatible('tbb') }}
     - eigen >=3.3.7,<3.4.0a0
-    # Require __cuda virtual package so the GPU variant only installs on hosts
-    # with a CUDA-capable driver; the CPU variant is preferred otherwise.
-    - __cuda >={{ cuda_compiler_version }}   # [cuda_compiler_version != "None"]
+    # __cuda gates the GPU variant to CUDA-capable hosts; the CPU variant
+    # (lower build number) installs everywhere else. Version is enforced
+    # transitively via cuda-version's run_constrained.
+    - __cuda                                 # [cuda_compiler_version != "None"]
 
 test:
   commands:
@@ -76,6 +77,9 @@ test:
     - if not exist %PREFIX%\\Library\\include\\ceres\\ceres.h exit 1  # [win]
     - if not exist %PREFIX%\\Library\\lib\\ceres.lib exit 1  # [win]
     - if not exist %PREFIX%\\Library\\bin\\ceres.dll exit 1  # [win]
+    # GPU smoke test: libceres must be dynamically linked against the CUDA
+    # math libs when built with CUDA — proves USE_CUDA=ON actually took effect.
+    - ldd ${PREFIX}/lib/libceres${SHLIB_EXT} | grep -qE "libcublas|libcusolver|libcusparse"   # [cuda_compiler_version != "None"]
 
 about:
   # HTTPS isn't supported by the ceres-solver.org website


### PR DESCRIPTION
ceres-solver 2.2.0

**Destination channel:** defaults

### Links

- [PKG-13203](https://anaconda.atlassian.net/browse/PKG-13203)
- Parent epic: [PKG-13074](https://anaconda.atlassian.net/browse/PKG-13074)
- Upstream repository: https://github.com/ceres-solver/ceres-solver
- Upstream `USE_CUDA` option: [CMakeLists.txt#L127-L129](https://github.com/ceres-solver/ceres-solver/blob/2.2.0/CMakeLists.txt#L127-L129)

### Explanation of changes:

- Adds GPU build variants for Ceres' CUDA-backed dense/sparse solvers on **linux (x86_64 + aarch64)** and **win-64** for CUDA **12.9** and **13.0**. The CPU build still ships on every platform; the GPU build is gated to CUDA-capable hosts via `__cuda` in `run`.
- The cuSparse-API risk originally flagged for CUDA 13.0 never surfaced; every 13.x-specific failure has been mechanical (arch list, line-ending preservation, C++ standard).

[PKG-13203]: https://anaconda.atlassian.net/browse/PKG-13203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-13074]: https://anaconda.atlassian.net/browse/PKG-13074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ