### PR TITLE
Explicitly pin openmp

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,5 +1,3 @@
-mkl:
-  - 2025
 
 # Keep cuda_compiler in the local CBC even when the aggregate sets it —
 # without it {{ compiler('cuda') }} fails to resolve at metadata-eval time.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@
 
 # Build number: bumped from 1 to 2 on this recipe revision; +100 for the
 # GPU variant so the solver prefers it when __cuda is satisfiable.
-{% set build = 2 %}
+{% set build = 3 %}
 {% set build = build + 100 if cuda_enabled else build %}
 
 package:
@@ -43,7 +43,9 @@ requirements:
     - mkl-devel {{ mkl }}.*           # [blas_impl == "mkl"]
     - mkl {{ mkl }}.*                 # [blas_impl == "mkl"]
     - openblas {{ openblas }}         # [blas_impl == "openblas"]
-    # For openblas on win and linux, we don't specify any openmp implementation; it comes from the compiler.
+    - libgomp                         # [blas_impl == "openblas" and linux]
+    - llvm-openmp                     # [blas_impl == "openblas" and osx]
+    - vcomp14                         # [blas_impl == "openblas" and (win and x86_64)]
     - intel-openmp {{ mkl }}          # [blas_impl == "mkl"]
     - suitesparse 7.8.3
     - tbb 2022.*
@@ -60,8 +62,9 @@ requirements:
     - libopenblas                     # [blas_impl == "openblas"]
     # OpenMP
     - {{ pin_compatible('intel-openmp') }}   # [blas_impl == "mkl"]
-    # To stop the compiler pulling in an openmp implementation itself
-    - _openmp_mutex                   # [linux]
+    - libgomp                         # [blas_impl == "openblas" and linux]
+    - llvm-openmp                     # [blas_impl == "openblas" and osx]
+    - vcomp14                         # [blas_impl == "openblas" and (win and x86_64)]
     - glog 0.7.1
     - gflags {{ gflags }}
     - {{ pin_compatible('suitesparse') }}


### PR DESCRIPTION
ceres-solver openmp rebuild
**Destination channel:** defaults

### Links

- [PKG-14739](https://anaconda.atlassian.net/browse/PKG-14739) 

### Explanation of changes:

- Bump build number
- Explicitly pin the openmp_impl being used

[OpenMP usage Audit](https://docs.google.com/spreadsheets/d/1Pln3E1WKlhasfR5NNyT9juhXrcM_63bQpAZRHDjNHtc/edit?usp=sharing)


[PKG-14739]: https://anaconda.atlassian.net/browse/PKG-14739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ